### PR TITLE
Pequena alteração que retira o CNPJ do Recibo

### DIFF
--- a/lib/boleto/gerador-de-boleto.js
+++ b/lib/boleto/gerador-de-boleto.js
@@ -122,7 +122,7 @@ var GeradorDeBoleto = (function() {
 					.lineTo(args.ajusteX + coluna3, args.ajusteY + (banco.exibirReciboDoPagadorCompleto() ? linha4Opcional : linha3))
 					.stroke(args.corDoLayout);
 
-				var coluna4 = 420;
+				var coluna4 = 480;
 				pdf.moveTo(args.ajusteX + coluna4, args.ajusteY + linha1)
 					.lineTo(args.ajusteX + coluna4, args.ajusteY + (banco.exibirReciboDoPagadorCompleto() ? linha3 : linha2))
 					.stroke(args.corDoLayout);
@@ -427,9 +427,10 @@ var GeradorDeBoleto = (function() {
 						align: 'left'
 					});
 
+				// foi feito alteração na linha 433 para que somente pegue o nome nesta linha
 				pdf.font('normal')
 					.fontSize(args.tamanhoDaFonte) // TODO: Diminuir tamanho da fonte caso seja maior que X caracteres
-					.text(pagador.getIdentificacao(), args.ajusteX + 32, args.ajusteY + primeiraLinha, {
+					.text(pagador._nome, args.ajusteX + 32, args.ajusteY + primeiraLinha, {
 						lineBreak: false,
 						width: 294,
 						align: 'left'

--- a/lib/formatacoesUtils.js
+++ b/lib/formatacoesUtils.js
@@ -207,7 +207,6 @@ function cnpj(texto) {
 	if(texto.trim().length > 14) return texto;
 
 	texto = texto.trim();
-
 	return texto.substr(0, 2) + '.' +
         texto.substr(2, 3) + '.' +
         texto.substr(5, 3) + '/' +
@@ -221,7 +220,6 @@ function cpf(texto) {
 	if(texto.trim().length > 11) return texto;
 
 	texto = texto.trim();
-
 	return texto.substr(0, 3) + '.' +
         texto.substr(3, 3) + '.' +
         texto.substr(6, 3) + '-' +
@@ -246,7 +244,6 @@ module.exports.pisPasep = pisPasep;
 module.exports.registroNacional = registroNacional;
 function registroNacional(texto) {
 	var tipo = validacoes.eRegistroNacional(texto);
-
 	if(!tipo) {
 		return texto;
 	}

--- a/lib/validacoesUtils.js
+++ b/lib/validacoesUtils.js
@@ -82,7 +82,6 @@ function eRegistroNacional(rn, tipo){
 	if(typeof rn !== 'string') {
 		return false;
 	}
-
 	rn = formatacoes.removerMascara(rn);
 
 	if(typeof tipo === 'undefined') {


### PR DESCRIPTION
Pequena alteração que retira o CNPJ do Recibo pois quando havia muitos espaços, quebrava e ocupava a linha de baixo